### PR TITLE
Promote Learn in the footer of all pages

### DIFF
--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -1,7 +1,6 @@
 class Show < ActiveRecord::Base
   has_many :episodes
 
-  validates :credits, presence: true
   validates :description, presence: true
   validates :email, presence: true
   validates :itunes_url, presence: true

--- a/app/views/episodes/_credits.html.erb
+++ b/app/views/episodes/_credits.html.erb
@@ -1,3 +1,0 @@
-<% content_for :footer do %>
-  <p><%== show.credits %></p>
-<% end %>

--- a/app/views/episodes/index.html.erb
+++ b/app/views/episodes/index.html.erb
@@ -8,5 +8,3 @@
 <section id='posts'>
   <%= render @show.episodes.published %>
 </section>
-
-<%= render 'credits', show: @show %>

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -50,5 +50,3 @@
     </section>
   </article>
 </section>
-
-<%= render 'credits', show: @episode.show %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,24 @@
     <footer>
       <section id="footer-container">
         <section class="etc">
-          <%= yield(:footer) %>
+          <p>
+            Don't just sit there.
+            <a href="http://learn.thoughtbot.com?utm_source=thoughtbot&utm_medium=podcasts&utm_campaign=footer">Learn something.</a>
+          </p>
+          <nav>
+            <ul>
+              <li>
+                <a href='http://twitter.com/thoughtbot' id='twitter'>
+                  twitter
+                </a>
+              </li>
+              <li>
+                <a href='http://tinyletter.com/thoughtbot' id='contact'>
+                  newsletter
+                </a>
+              </li>
+            </ul>
+          </nav>
         </section>
       </section>
     </footer>

--- a/app/views/shows/index.html.erb
+++ b/app/views/shows/index.html.erb
@@ -1,11 +1,3 @@
 <% content_for :header do %>
   <% render @shows %>
 <% end %>
-
-<% content_for :footer do %>
-  <p>
-    <a href="http://robots.thoughtbot.com">Blog</a> •
-    Don't just sit there.
-    <a href="http://learn.thoughtbot.com">Learn something.</a>
-  </p>
-<% end %>

--- a/db/migrate/20131229201852_remove_credits.rb
+++ b/db/migrate/20131229201852_remove_credits.rb
@@ -1,0 +1,9 @@
+class RemoveCredits < ActiveRecord::Migration
+  def up
+    remove_column :shows, :credits
+  end
+
+  def down
+    add_column :shows, :credits, :text, default: '', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131228204242) do
+ActiveRecord::Schema.define(version: 20131229201852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,7 +72,6 @@ ActiveRecord::Schema.define(version: 20131228204242) do
     t.string   "title",             null: false
     t.string   "short_description", null: false
     t.text     "description",       null: false
-    t.text     "credits",           null: false
     t.string   "keywords",          null: false
     t.string   "itunes_url",        null: false
     t.string   "stitcher_url"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,7 +10,6 @@ FactoryGirl.define do
 
   factory :show do
     email
-    credits 'Some people'
     description 'Some people talking'
     itunes_url 'http://itunes.com'
     keywords 'design, development'

--- a/spec/models/show_spec.rb
+++ b/spec/models/show_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Show do
   it { should have_many(:episodes) }
 
-  it { should validate_presence_of(:credits) }
   it { should validate_presence_of(:description) }
   it { should validate_presence_of(:email) }
   it { should validate_presence_of(:itunes_url) }


### PR DESCRIPTION
- The footer previously contained credits, which were largely redundant
  with the subheader of the episodes#index and episodes#show pages.
- Credits are no longer used in the app's views, but may be necessary
  for iTunes data, so they were not removed.

https://trello.com/c/SjRNEMYM
