### PR TITLE
Improve meta tags for better SEO

### DIFF
--- a/app/views/episodes/index.html.erb
+++ b/app/views/episodes/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, @show.title %>
+<% content_for :meta_description, @show.short_description %>
 
 <% content_for :header do %>
   <% render @show %>

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, "#{@episode.show.title} : #{@episode.full_title}" %>
+<% content_for :meta_description, @episode.description %>
 
 <% content_for :header do %>
   <%= render @episode.show %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,7 @@
 <html lang="en">
   <head prefix="og: http://ogp.me/ns#">
     <meta charset="utf-8" />
-    <meta http-equiv="Description" name="Description" content="<%= yield(:meta_description) %>" />
-    <meta http-equiv="Keywords" name="Keywords" content="<%= yield :meta_keywords %>" />
+    <meta http-equiv="Description" name="Description" content="<%= yield(:meta_description) || "Weekly podcasts from thoughtbot on design, Ruby on Rails, iOS, and the programmer lifestyle." %>" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= csrf_meta_tags %>
     <%= yield :meta %>


### PR DESCRIPTION
- Remove meta keywords. They are not used by Google in search results.
  http://www.mattcutts.com/blog/keywords-meta-tag-in-web-search/
- Use ad-like copy for home page description, which is used in search
  engine results pages.
- Use shows' short description and episodes' description so that the
  same description is not used on every page, and to improve
  click-through rate on search engine results pages.

https://trello.com/c/3rO5yDi2
