### PR TITLE
Style index page like blog's tag pages

### DIFF
--- a/app/views/episodes/_episode.html.erb
+++ b/app/views/episodes/_episode.html.erb
@@ -1,18 +1,17 @@
-<article class='post text'>
+<article class='post text tag-post'>
   <h1 class='title'>
     <%= link_to episode.title, [episode.show, episode] %>
   </h1>
 
-  <aside class='meta-info'>
+  <aside class='meta-info tag-result'>
     <p class='episode-number'>
       <%= link_to [episode.show, episode] do %>
         Episode #<%= episode.number %>
       <% end %>
     </p>
     <p class='post-date'>
-      <%= episode.published_on.to_time.to_s(:short_date) %>
+      <%= l episode.published_on %>
     </p>
-    <p><%= distance_of_time_in_words episode.duration.to_f %></p>
   </aside>
 
   <p><%= episode.description %></p>

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -17,7 +17,10 @@
         <% end %>
       </p>
       <p class='post-date'>
-        <%= @episode.published_on.to_time.to_s(:short_date) %>
+        <%= l @episode.published_on %>
+      </p>
+      <p>
+        <%= distance_of_time_in_words @episode.duration.to_f %>
       </p>
     </aside>
 
@@ -32,8 +35,7 @@
       <%= link_to show_episode_path(@episode.show, @episode, format: :mp3) do %>
         Direct Download
       <% end %>
-      (<%= number_to_human_size @episode.file_size, precision: 2 %>,
-      <%= distance_of_time_in_words @episode.duration.to_f %>)
+      (<%= number_to_human_size @episode.file_size, precision: 2 %>)
     </div>
 
     <% unless @episode.notes.blank? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,7 @@
 en:
   date:
     formats:
-      default: '%m/%d/%Y'
+      default: '%-d %B %Y'
       with_weekday: '%a %m/%d/%y'
 
   time:
@@ -9,5 +9,6 @@ en:
       default: '%a, %b %-d, %Y at %r'
       date: '%b %-d, %Y'
       short: '%B %d'
+
   layouts:
     app_name: thoughtbot

--- a/spec/features/visitor_views_podcast_spec.rb
+++ b/spec/features/visitor_views_podcast_spec.rb
@@ -21,9 +21,9 @@ feature 'Viewing a podcast' do
     visit show_episodes_path(episode1.show)
 
     expect(page).to have_title "thoughtbot : #{episode1.show.title}"
+    expect(page).to have_content "Episode ##{episode1.number}"
     expect(page).to have_content 'Good episode'
     expect(page).to have_content 'this was good'
-    expect(page).to have_content '20 minutes'
     expect(page).to have_content 'Not so good'
     expect(page).to have_content 'this was bad'
     expect(page).not_to have_content 'Future episode'
@@ -52,10 +52,10 @@ feature 'Viewing a podcast' do
 
     within 'aside' do
       expect(page).to have_content("Episode ##{episode.number}")
+      expect(page).to have_content('20 minutes')
     end
 
-    expect(page).to have_css('.listen', text: %r{13 MB,})
-    expect(page).to have_css('.listen', text: /20 minutes/)
+    expect(page).to have_css('.listen', text: /13 MB/)
   end
 
   def expect_to_see_audio_player(episode)


### PR DESCRIPTION
- Use smaller header text and less space between episodes so it is
  easier to see and read more of the list.
- With a tighter list, drop episode duration to avoid crowding.
- Move episode duration to sidebar on episodes#show to better highlight
  that information and feel more like our blog style.
- Use localization for dates.
- Use "25 December 2013" style per recommendation from Strunk and
  White's "Elements of Style".

> The last form is an excellent way to write a date; the figures are
> separated by a word and are, for that reason, quickly grasped.

https://trello.com/c/qfsVNKb2
